### PR TITLE
Fixed error caused by releasing a authorized item from the listViewAuthorizationDecisions control.

### DIFF
--- a/Tenduke.Client.WPFSample/MainWindow.xaml.cs
+++ b/Tenduke.Client.WPFSample/MainWindow.xaml.cs
@@ -346,7 +346,9 @@ namespace Tenduke.Client.WPFSample
             bool noConsumptionFound = "noConsumptionFoundById" == (string)response[tokenId + "_errorCode"];
             if (successfullyReleased || noConsumptionFound)
             {
-                listViewAuthorizationDecisions.Items.Remove(selectedItem);
+                ObservableCollection<AuthorizationDecisionItem> source = listViewAuthorizationDecisions.ItemsSource as ObservableCollection<AuthorizationDecisionItem>;
+                if (source != null)
+                    source.Remove(selectedItem);
             }
             else
             {


### PR DESCRIPTION
Changed the code to removed the selected item from the data bound source rather than the control itself.