### PR TITLE
Refactor / move WMI related code to Tenduke.Desktop.Client

### DIFF
--- a/Tenduke.Client.AspNetSample/npm-shrinkwrap.json
+++ b/Tenduke.Client.AspNetSample/npm-shrinkwrap.json
@@ -2271,7 +2271,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2292,12 +2293,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2312,17 +2315,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2439,7 +2445,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2451,6 +2458,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2465,6 +2473,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2472,12 +2481,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2496,6 +2507,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2576,7 +2588,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2588,6 +2601,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2673,7 +2687,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2709,6 +2724,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2728,6 +2744,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2771,12 +2788,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/Tenduke.Client.Desktop/BaseDesktopClient.cs
+++ b/Tenduke.Client.Desktop/BaseDesktopClient.cs
@@ -56,17 +56,17 @@ namespace Tenduke.Client.Desktop
                 var retValue = computerId;
                 if (retValue == null)
                 {
-                    Tenduke.Client.Util.ComputerIdentity.ComputerIdentifier[] idComponents =
+                    ComputerIdentity.ComputerIdentifier[] idComponents =
                         ComputerIdentityConfig == null || (ComputerIdentityConfig.ComputeBy == null && ComputerIdentityConfig.AdditionalIdentifier == null)
-                        ? new[] { Tenduke.Client.Util.ComputerIdentity.ComputerIdentifier.BaseboardSerialNumber } // Uses BaseboardSerialNumber as default
+                        ? new[] { ComputerIdentity.ComputerIdentifier.BaseboardSerialNumber } // Uses BaseboardSerialNumber as default
                         : ComputerIdentityConfig.ComputeBy;
                     if (ComputerIdentityConfig == null)
                     {
-                        retValue = Tenduke.Client.Util.ComputerIdentity.BuildComputerId(null, null, idComponents);
+                        retValue = ComputerIdentity.BuildComputerId(null, null, idComponents);
                     }
                     else if (ComputerIdentityConfig.ComputerId == null)
                     {
-                        retValue = Tenduke.Client.Util.ComputerIdentity.BuildComputerId(ComputerIdentityConfig.AdditionalIdentifier, ComputerIdentityConfig.Salt, idComponents);
+                        retValue = ComputerIdentity.BuildComputerId(ComputerIdentityConfig.AdditionalIdentifier, ComputerIdentityConfig.Salt, idComponents);
                     }
                     else
                     {

--- a/Tenduke.Client.Desktop/Config/ComputerIdentityConfig.cs
+++ b/Tenduke.Client.Desktop/Config/ComputerIdentityConfig.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Tenduke.Client.Util;
+using Tenduke.Client.Desktop.Util;
 
 namespace Tenduke.Client.Desktop.Config
 {

--- a/Tenduke.Client.Desktop/Tenduke.Client.Desktop.csproj
+++ b/Tenduke.Client.Desktop/Tenduke.Client.Desktop.csproj
@@ -13,10 +13,10 @@
     <PackageIconUrl>https://raw.githubusercontent.com/10Duke/10duke-dotnet-client/master/10duke.ico</PackageIconUrl>
     <RepositoryUrl>https://github.com/10Duke/10duke-dotnet-client</RepositoryUrl>
     <PackageTags>Entitlement Licensing Identity 10Duke Desktop</PackageTags>
-    <AssemblyVersion>2.3.4.0</AssemblyVersion>
-    <FileVersion>2.3.4.0</FileVersion>
-    <Version>2.3.4</Version>
-    <PackageReleaseNotes>- Fallback logics for finding browser subprocess executable</PackageReleaseNotes>
+    <AssemblyVersion>3.0.0.0</AssemblyVersion>
+    <FileVersion>3.0.0.0</FileVersion>
+    <Version>3.0.0</Version>
+    <PackageReleaseNotes>- Move ComputerIdentifier class from the base client (Tenduke.Client) to this client</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tenduke.Client.Desktop/Tenduke.Client.Desktop.csproj
+++ b/Tenduke.Client.Desktop/Tenduke.Client.Desktop.csproj
@@ -29,7 +29,10 @@
 
   <ItemGroup>
     <PackageReference Include="CefSharp.Common" Version="75.1.143" />
-    <PackageReference Include="Tenduke.Client" Version="2.3.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Tenduke.Client\Tenduke.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Tenduke.Client.Desktop/Util/ComputerIdentity.cs
+++ b/Tenduke.Client.Desktop/Util/ComputerIdentity.cs
@@ -5,7 +5,7 @@ using System.Management;
 using System.Security.Cryptography;
 using System.Text;
 
-namespace Tenduke.Client.Util
+namespace Tenduke.Client.Desktop.Util
 {
     /// <summary>
     /// <para>Utilities for getting different pieces of information that may be used for identifying

--- a/Tenduke.Client.WPFSample/App.config
+++ b/Tenduke.Client.WPFSample/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-      <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+      <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
           <section name="Tenduke.Client.WPFSample.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
       </sectionGroup>
   </configSections>

--- a/Tenduke.Client/Tenduke.Client.csproj
+++ b/Tenduke.Client/Tenduke.Client.csproj
@@ -10,11 +10,11 @@
     <PackageIconUrl>https://raw.githubusercontent.com/10Duke/10duke-dotnet-client/master/10duke.ico</PackageIconUrl>
     <RepositoryUrl>https://github.com/10Duke/10duke-dotnet-client</RepositoryUrl>
     <PackageTags>Entitlement Licensing Identity 10Duke</PackageTags>
-    <PackageReleaseNotes>- Fallback logics for finding browser subprocess executable (applies to desktop clients only)</PackageReleaseNotes>
+    <PackageReleaseNotes>- Move ComputerIdentifier class to the desktop client (Tenduke.Client.Desktop)</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<IncludeSource>true</IncludeSource>
-    <Version>2.3.4</Version>
-    <AssemblyVersion>2.3.4.0</AssemblyVersion>
+    <Version>3.0.0</Version>
+    <AssemblyVersion>3.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
ComputerIdentifier class uses WMI that is not available in all environments that Tenduke.Client should support. Move this class to Tenduke.Client.Desktop.