### PR TITLE
Refactor ConfigurationReader to the ASP.NET Core client

### DIFF
--- a/Tenduke.Client.AspNetCore/Config/ConfigurationReader.cs
+++ b/Tenduke.Client.AspNetCore/Config/ConfigurationReader.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Security.Cryptography;
+using Tenduke.Client.Config;
+using Tenduke.Client.Util;
+
+namespace Tenduke.Client.AspNetCore.Config
+{
+    /// <summary>
+    /// Reading and accessing configurations required by the 10Duke client, based on an <see cref="IConfiguration" /> object.
+    /// </summary>
+    public class ConfigurationReader
+    {
+        #region Configuration interface implementations
+
+        protected class ConfigBase
+        {
+            protected IConfiguration Config { get; }
+
+            protected ConfigBase(IConfiguration config)
+            {
+                Config = config;
+            }
+        }
+
+        protected class OAuthConfig : ConfigBase, IOAuthConfig
+        {
+            internal OAuthConfig(IConfiguration config)
+                : base(config)
+            {
+            }
+
+            public string ClientID => Config["ClientId"];
+
+            public string Scope => Config["Scope"];
+
+            public string UserInfoUri => Config["UserInfoUri"];
+
+            public bool ShowRememberMe => string.IsNullOrEmpty(Config["ShowRememberMe"]) ? false : bool.Parse(Config["ShowRememberMe"]);
+        }
+
+        protected class BrowserBasedAuthorizationConfig : OAuthConfig, IBrowserBasedAuthorizationConfig
+        {
+            internal BrowserBasedAuthorizationConfig(IConfiguration config)
+                : base(config)
+            {
+            }
+
+            public string RedirectUri => Config["RedirectUri"];
+
+            public string AuthzUri => Config["AuthzUri"];
+
+            public string Issuer => Config["Issuer"];
+
+            public RSA SignerKey => CryptoUtil.ReadRsaPublicKey(Config["SignerKey"]);
+        }
+
+        protected class AuthorizationCodeGrantConfig : BrowserBasedAuthorizationConfig, IAuthorizationCodeGrantConfig
+        {
+            internal AuthorizationCodeGrantConfig(IConfiguration config)
+                : base(config)
+            {
+            }
+
+            public string ClientSecret => Config["ClientSecret"];
+
+            public string TokenUri => Config["TokenUri"];
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Gets an object for accessing OAuth Authorization Code Grant configuration.
+        /// </summary>
+        /// <param name="config"><see cref="IConfiguration"/> object for accessing configuration settings.</param>
+        /// <returns>An <see cref="IAuthorizationCodeGrantConfig"/> object for accessing the OAuth Authorization Code Grant configuration.</returns>
+        public static IAuthorizationCodeGrantConfig AuthorizationCodeGrantConfigFromConfiguration(IConfiguration config) => new AuthorizationCodeGrantConfig(config);
+
+        #endregion
+    }
+}

--- a/Tenduke.Client.AspNetCore/Tenduke.Client.AspNetCore.csproj
+++ b/Tenduke.Client.AspNetCore/Tenduke.Client.AspNetCore.csproj
@@ -24,7 +24,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
-    <PackageReference Include="Tenduke.Client" Version="2.3.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Tenduke.Client\Tenduke.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Tenduke.Client.AspNetCore/Tenduke.Client.AspNetCore.csproj
+++ b/Tenduke.Client.AspNetCore/Tenduke.Client.AspNetCore.csproj
@@ -11,11 +11,11 @@
     <PackageProjectUrl>https://github.com/10Duke/10duke-dotnet-client</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/10Duke/10duke-dotnet-client/master/10duke.ico</PackageIconUrl>
     <RepositoryUrl>https://github.com/10Duke/10duke-dotnet-client</RepositoryUrl>
-    <PackageReleaseNotes>Update to Tenduke.Client version 2.3.4</PackageReleaseNotes>
+    <PackageReleaseNotes>- Move ConfigurationReader from Tenduke.Client to this project</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<IncludeSource>true</IncludeSource>
-    <Version>2.3.4</Version>
-    <AssemblyVersion>2.3.4.0</AssemblyVersion>
+    <Version>3.0.0</Version>
+    <AssemblyVersion>3.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tenduke.Client/Tenduke.Client.csproj
+++ b/Tenduke.Client/Tenduke.Client.csproj
@@ -10,7 +10,8 @@
     <PackageIconUrl>https://raw.githubusercontent.com/10Duke/10duke-dotnet-client/master/10duke.ico</PackageIconUrl>
     <RepositoryUrl>https://github.com/10Duke/10duke-dotnet-client</RepositoryUrl>
     <PackageTags>Entitlement Licensing Identity 10Duke</PackageTags>
-    <PackageReleaseNotes>- Move ComputerIdentifier class to the desktop client (Tenduke.Client.Desktop)</PackageReleaseNotes>
+    <PackageReleaseNotes>- Move ComputerIdentifier class to the desktop client (Tenduke.Client.Desktop)
+- Move ConfigurationReader class to the ASP.NET Core client (Tenduke.Client.AspNetCore)</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<IncludeSource>true</IncludeSource>
     <Version>3.0.0</Version>


### PR DESCRIPTION
Move ConfigurationReader from Tenduke.Client.Config to Tenduke.Client.AspNetCore.Config as this is only needed by ASP.NET applications.