### PR TITLE
Update release notes tag in project file

### DIFF
--- a/Tenduke.Client/Tenduke.Client.csproj
+++ b/Tenduke.Client/Tenduke.Client.csproj
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/10Duke/10duke-dotnet-client.git</RepositoryUrl>
     <PackageReadMeFile>README.md</PackageReadMeFile>
     <PackageTags>Entitlement Licensing Identity 10Duke</PackageTags>
-    <PackageReleaseNotes>Dependency updates</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/10Duke/10duke-dotnet-client/releases</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSource>true</IncludeSource>
     <Version>4.0.0</Version>


### PR DESCRIPTION
Makes the release notes tag for the nuget package release notes a URL to the releases page on github rather than text embedded in the project file.
This should mean that the tag does not need to be updated for each release, the person reading the nuget package page on nuget.org can simply go to the release notes for the specific release on the github releases page.